### PR TITLE
Save algebra expressions with user defined relations (for inlining).

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,8 @@
 </script>
     <script src="js/value_column.js" type="text/javascript" charset="utf-8">
 </script>
+    <script src="js/expression_division.js" type="text/javascript" charset="utf-8">
+</script>
 
     <script src="lib/jquery-1.3.2.js" type="text/javascript" charset="utf-8">
 </script>
@@ -157,6 +159,9 @@
           </li>
           <li style="margin-top:15px;">
             <a href="javascript:;" onclick="addMinus()">$\large{\setminus}$ - Minus einsetzen</a>
+          </li>
+          <li>
+            <a href="javascript:;" onclick="addDivision()">$\large{\div}$ - Division einsetzen</a>
           </li>
           <li>
             <a href="javascript:;" onclick="addUnion()">$\large{\cup}$ - Vereinigung einsetzen</a>

--- a/index.html
+++ b/index.html
@@ -275,6 +275,7 @@
     <div class="ui-widget-content ui-corner-all ui-widget ui-tabs" style="min-height: 65px">
       <div class="ui-widget-header ui-corner-all">
         Ausdruck in $\large{\LaTeX}$: 
+        <a href="javascript:;" onclick="toggleDisplayFull()">(extend)</a>
         <a href="javascript:;" onclick="reset()">(reset)</a>
         <a href="javascript:;" onclick="back()">(back)</a>
       </div>

--- a/index.html
+++ b/index.html
@@ -221,6 +221,9 @@
           <li>
             <a href="javascript:;" onclick="addDataRelation(zehnkampf)">$\large{Zehnkampf}$ Relation einsetzen</a>
           </li>
+          <li>
+            <a href="javascript:;" onclick="addDataRelation(zehnkampfd)">$\large{ZehnkampfD}$ Relation einsetzen</a>
+          </li>
         </ul>
         <ul style="float:left" id="savelist">
           <li style="display:none">&nbsp;</li>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>
       IRA - Interaktive Relationale Algebra ;)
     </title>
-	  
+
 	  <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
   	tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]},
@@ -24,9 +24,9 @@
 </script>
 	  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 	  <!--<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_SVG"></script>-->
-		  
-		
-    
+
+
+
 	  <script src="js/block.js" type="text/javascript" charset="utf-8"></script>
 	  <script src="js/relation.js" type="text/javascript" charset="utf-8"></script>
     <script src="js/data_relation.js" type="text/javascript" charset="utf-8">
@@ -104,10 +104,10 @@
     </style>
   </head>
   <body>
-	
-    <!--<h2> Editierbereich 
+
+    <!--<h2> Editierbereich
       <span style="color: darkgreen; font-size:80%">
-      (<a target="_NEW" href="movie1.mov" style="color: darkgreen; ">Lehrvideo (Quicktime, VLC), am besten Rechtklick, speichern.</a>)      
+      (<a target="_NEW" href="movie1.mov" style="color: darkgreen; ">Lehrvideo (Quicktime, VLC), am besten Rechtklick, speichern.</a>)
       </span>
       </h2>-->
     <div id="display_expression" style="font-size: 16pt; font-family: courier;text-align:center; margin-top:30px"></div><!--<h2>
@@ -121,9 +121,9 @@
       });
     //]]>
     </script>
-    
+
     <div>
-    
+
     <div id="tabs" style="min-height:250px; margin-top:30px;">
       <ul>
         <li>
@@ -136,7 +136,7 @@
           <a href="#tab3"><span>für Werte</span></a>
         </li>
       </ul>
-      
+
       <div id="tab1" class="toolbox toolbox_expressions">
         <ul style="float:left;">
           <li>
@@ -274,16 +274,16 @@
 
     <div class="ui-widget-content ui-corner-all ui-widget ui-tabs" style="min-height: 65px">
       <div class="ui-widget-header ui-corner-all">
-        Ausdruck in $\large{\LaTeX}$: 
-        <a href="javascript:;" onclick="toggleDisplayFull()">(extend)</a>
+        Ausdruck in $\large{\LaTeX}$:
+        <a href="javascript:;" onclick="toggleInlineUserDefinedRelations()">(inline)</a>
         <a href="javascript:;" onclick="reset()">(reset)</a>
         <a href="javascript:;" onclick="back()">(back)</a>
       </div>
       <div class="ui-tabs-panel ui-widget-content" id="display_expression_latex"></div>
     </div>
-    
+
     <br />
-    
+
     <div class="ui-widget-content ui-corner-all ui-widget ui-tabs">
       <div class="ui-widget-header ui-corner-all">
         Ergebnis <a href="javascript:;" onclick="save(prompt('Name?'))" style="font-size: 11px;">(speichern)</a>
@@ -294,8 +294,8 @@
       </div>
     </div>
     </div>
-    
-    
+
+
     <script type="text/javascript">
 //<![CDATA[
 var newsid = 3;
@@ -318,24 +318,24 @@ if (c.lastNews != newsid || c.count != 0) {
 
     <div id="hilfe">
       <h2> Neuerung 17.11.2009, 20:28: Zurück Knopf </h2>
-      
+
       Der viel geforderte und zugegebenermaßen sehr wichtige Back Button ist jetzt da. Falls jemand wissen will, wieso dieser so sau schwer zu erzeugen ist, melde er sich schriftlich oder in einer Übung bei mir ;-)
-      
+
       <h2> Neuerung 17.11.2009, 20:01: Diverses </h2>
-      
+
       In Input Dialogen abbrechen geht jetzt. LaTeX Ausdrücke mit einem Unterstrich in einer Bedingung gehen jetzt. Siehe auch die Bugs Seite. Danke an alle "Helfer".
-      
+
       <h2> Lehrvideo </h2>
       Du kannst mit Quicktime / VLC <a href="movie1.mov" target="NEW">hier</a> ein kurzes Video zur Bedienung ansehen!
-      
+
       <br /><hr />
-      Du siehst diesen Dialog noch 
+      Du siehst diesen Dialog noch
       <script type="text/javascript">
         document.write(c.count);
       </script>
       mal.
     </div>
-    
+
     <script type="text/javascript">
 //<![CDATA[
 if (false && showNews) {
@@ -354,7 +354,7 @@ reset();
 updateDisplay(true);
 //]]>
     </script>
-    
+
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -365,15 +365,15 @@ updateDisplay(true);
   ga('send', 'pageview');
 
 </script>
-    
-    
-    
+
+
+
     <hr />
     <p>
       <a href="mailto:db@muehe.org">Henrik Mühe</a>
       <a href="http://www-db.in.tum.de/~muehe/">homepage</a>, 2009-2012
-      
-      - Bitte Bugs via <a href="https://github.com/harald-lang/ira/issues">GitHub</a> melden! 
+
+      - Bitte Bugs via <a href="https://github.com/harald-lang/ira/issues">GitHub</a> melden!
       - <a href="bugs.html">Bekannte Bugs</a>
 	<p>
 		<a href="http://www.mathjax.org">
@@ -382,8 +382,8 @@ updateDisplay(true);
 			border="0" alt="Powered by MathJax" />
 		</a>
 	</p>
-    
-        
-    
+
+
+
   </body>
 </html>

--- a/js/condition_and.js
+++ b/js/condition_and.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -30,14 +30,14 @@ function ConditionAnd(cond1, cond2) {
         return this.cond1.toJS() + " && " + this.cond2.toJS();
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '(';
-        display += this.cond1.toHTML() + latex('\\wedge') + this.cond2.toHTML() + ")";
+        display += this.cond1.toHTML(options) + latex('\\wedge') + this.cond2.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return '(' + this.cond1.toLatex() + '\\wedge ' + this.cond2.toLatex() + ')';
+    this.toLatex = function(options) {
+        return '(' + this.cond1.toLatex(options) + '\\wedge ' + this.cond2.toLatex(options) + ')';
     }
 }
 ConditionAnd.prototype = new Condition;

--- a/js/condition_comparison.js
+++ b/js/condition_comparison.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -49,14 +49,14 @@ function ConditionComparison(op, value1, value2) {
         }
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += this.value1.toHTML() + latex(this.opToLatex(this.op)) + this.value2.toHTML() + '';
+        display += this.value1.toHTML(options) + latex(this.opToLatex(this.op)) + this.value2.toHTML(options) + '';
         return display;
     }
 
-    this.toLatex = function() {
-        return this.value1.toLatex() + this.opToLatex(this.op) + ' ' + this.value2.toLatex();
+    this.toLatex = function(options) {
+        return this.value1.toLatex(options) + this.opToLatex(this.op) + ' ' + this.value2.toLatex(options);
     }
 }
 ConditionComparison.prototype = new Condition;

--- a/js/condition_not.js
+++ b/js/condition_not.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -29,14 +29,14 @@ function ConditionNot(cond) {
         return "!(" + this.cond.toJS() + ")";
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '(';
-        display += latex("\\neg") + this.cond.toHTML() + ")";
+        display += latex("\\neg") + this.cond.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return '\\neg ' + this.cond.toLatex();
+    this.toLatex = function(options) {
+        return '\\neg ' + this.cond.toLatex(options);
     }
 }
 ConditionNot.prototype = new Condition;

--- a/js/condition_or.js
+++ b/js/condition_or.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -30,14 +30,14 @@ function ConditionOr(cond1, cond2) {
         return this.cond1.toJS() + " || " + this.cond2.toJS();
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '(';
-        display += this.cond1.toHTML() + latex('\\vee') + this.cond2.toHTML() + ')';
+        display += this.cond1.toHTML(options) + latex('\\vee') + this.cond2.toHTML(options) + ')';
         return display;
     }
 
-    this.toLatex = function() {
-        return '(' + this.cond1.toLatex() + '\\vee ' + this.cond2.toLatex() + ')';
+    this.toLatex = function(options) {
+        return '(' + this.cond1.toLatex(options) + '\\vee ' + this.cond2.toLatex(options) + ')';
     }
 }
 ConditionOr.prototype = new Condition;

--- a/js/data_relation.js
+++ b/js/data_relation.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -22,7 +22,7 @@ function DataRelation(name, columns, data, expr) {
     this.expression = expr;
 
     this.copy = function() {
-        return new DataRelation(name, columns, data);
+        return new DataRelation(name, columns, data, expr);
     }
 
     this.getName = function() {
@@ -39,12 +39,17 @@ function DataRelation(name, columns, data, expr) {
         return this.data;
     }
 
-    this.toHTML = function() {
-        return latex(this.toLatex());
+    this.toHTML = function(options) {
+        return latex(this.toLatex(options));
     }
 
-    this.toLatex = function() {
-        return showFull && this.expression != undefined ? this.expression.toLatex() : this.name;
+    this.toLatex = function(options) {
+        if (options && options.inline) {
+          return this.expression != undefined ? this.expression.toLatex(options) : this.name;
+        } else {
+          return this.name;
+        }
     }
+
 }
 DataRelation.prototype = new Relation;

--- a/js/data_relation.js
+++ b/js/data_relation.js
@@ -15,10 +15,11 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-function DataRelation(name, columns, data) {
+function DataRelation(name, columns, data, expr) {
     this.name = name;
     this.columns = columns;
     this.data = data;
+    this.expression = expr;
 
     this.copy = function() {
         return new DataRelation(name, columns, data);
@@ -39,11 +40,11 @@ function DataRelation(name, columns, data) {
     }
 
     this.toHTML = function() {
-        return latex(this.name);
+        return latex(this.toLatex());
     }
 
     this.toLatex = function() {
-        return this.name;
+        return showFull && this.expression != undefined ? this.expression.toLatex() : this.name;
     }
 }
 DataRelation.prototype = new Relation;

--- a/js/expression_conditional_join.js
+++ b/js/expression_conditional_join.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -41,7 +41,7 @@ function ConditionalJoin(condition, input1, input2) {
         return columns;
     }
     this.setColumns = null;
-    
+
     this.getResult = function() {
         var cols = this.getColumns();
         var cond = this.condition.toJS();
@@ -69,14 +69,14 @@ function ConditionalJoin(condition, input1, input2) {
         return new ConditionalJoin(this.condition.copy(), this.input1.copy(), this.input2.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.input1.toHTML() + " " + latex("\\bowtie") + "<span style='font-size:10pt; vertical-align: bottom'>" + this.condition.toHTML() + "</span> " + " " + this.input2.toHTML() + ")";
+        display += '(' + this.input1.toHTML(options) + " " + latex("\\bowtie") + "<span style='font-size:10pt; vertical-align: bottom'>" + this.condition.toHTML(options) + "</span> " + " " + this.input2.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.input1.toLatex() + "\\bowtie_{" + this.condition.toLatex() + "} " + this.input2.toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.input1.toLatex(options) + "\\bowtie_{" + this.condition.toLatex(options) + "} " + this.input2.toLatex(options) + ")";
     }
 }
 ConditionalJoin.prototype = new Relation;

--- a/js/expression_crossproduct.js
+++ b/js/expression_crossproduct.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -54,13 +54,13 @@ function Crossproduct(input1, input2) {
 
     this.getResult = function() {
         this.checkValidity();
-        
+
         var rel1 = this.input1.getResult();
         var cols1 = this.input1.getColumns();
         var rel2 = this.input2.getResult();
         var cols2 = this.input2.getColumns();
         var result = [];
-        
+
         if (rel1.length * rel2.length > 2000) {
             throw "Das Kreuzprodukt ist zu groß, dein Browser würde abstürzen.";
         }
@@ -79,14 +79,14 @@ function Crossproduct(input1, input2) {
         return new Crossproduct(this.input1.copy(), this.input2.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.input1.toHTML() + " " + latex("\\times") + " " + this.input2.toHTML() + ")";
+        display += '(' + this.input1.toHTML(options) + " " + latex("\\times") + " " + this.input2.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.input1.toLatex() + "\\times " + this.input2.toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.input1.toLatex(options) + "\\times " + this.input2.toLatex(options) + ")";
     }
 }
 Crossproduct.prototype = new Relation;

--- a/js/expression_division.js
+++ b/js/expression_division.js
@@ -1,0 +1,86 @@
+function Division(input1, input2) {
+    this.input1 = input1;
+    this.input2 = input2;
+
+    this.setChildren([this.input1, this.input2]);
+
+
+    this.getName = function() {
+        return this.input1.getName() + "_" + this.input2.getName();
+    };
+    this.setName = null;
+
+    this.validate = function() {
+        if (this.input1.getColumns() == null || this.input2.getColumns() == null) {
+            throw "Es fehlt mindestens eine Eingaberelation.";
+        }
+    };
+
+    this.getColumns = function() {
+        this.validate();
+        var result = [];
+        var columns = this.input1.getColumns().clone();
+        var dividerColumns = this.input2.getColumns().clone();
+        var isInColumns = function(name, columnArray) {
+          for (var i = 0; i<columnArray.length;i++) {
+            if (columnArray[i] === name) {
+              return true;
+            }
+          }
+          return false;
+        };
+        for (var i = 0; i<columns.length;i++) {
+          if (!isInColumns(columns[i], dividerColumns)) {
+            result.push(columns[i]);
+          }
+        }
+        return result;
+    };
+    this.setColumns = null;
+
+    this.getResult = function() {
+
+        this.validate();
+
+        var cols = this.getColumns();
+
+        console.log(cols);
+
+        var pro = new Projection(cols.toString(), this.input1);
+
+        var cp = new Crossproduct(pro, this.input2);
+
+        var namingCommand = "";
+
+        var cpColumns = cp.getColumns();
+
+        for (var i=0;i<cpColumns.length;i++) {
+          namingCommand += cpColumns[i].split(".")[1] + "<-" + cpColumns[i] + ",";
+        }
+
+        var newNames = new Rename(namingCommand,cp);
+
+        var min = new Minus(newNames, this.input1);
+
+        var proj = new Projection(cols.toString(), min);
+
+        min = new Minus(pro, proj);
+
+        return min.getResult();
+    };
+
+    this.copy = function() {
+        return new Division(this.input1.copy(), this.input2.copy());
+    };
+
+    this.toHTML = function(options) {
+        var display = '';
+        display += '(' + this.input1.toHTML(options) + " " + latex("\\div") +  " " + this.input2.toHTML(options) + ")";
+        return display;
+    };
+
+    this.toLatex = function(options) {
+        return "(" + this.input1.toLatex(options) + "\\div " + this.input2.toLatex(options) + ")";
+    };
+}
+Division.prototype = new Relation();

--- a/js/expression_division.js
+++ b/js/expression_division.js
@@ -11,9 +11,23 @@ function Division(input1, input2) {
     this.setName = null;
 
     this.validate = function() {
-        if (this.input1.getColumns() == null || this.input2.getColumns() == null) {
-            throw "Es fehlt mindestens eine Eingaberelation.";
+      var leftInputColumns = this.input1.getColumns();
+      var rightInputColumns = this.input2.getColumns()
+      if (leftInputColumns == null || rightInputColumns == null) {
+          throw "Es fehlt mindestens eine Eingaberelation.";
+      }
+
+      var commonColumnCount = 0;
+      for (var i = 0; i<rightInputColumns.length;i++) {
+        if (leftInputColumns.indexOf(rightInputColumns[i]) === -1) {
+          throw "Das Schema der rechten Eingaberelation ist keine (echte) Teilmenge des Schemas der linken Eingaberelation.";
+        } else {
+          commonColumnCount++;
         }
+      }
+      if (commonColumnCount === leftInputColumns.length) {
+        throw "Das Schema der rechten Eingaberelation ist keine (echte) Teilmenge des Schemas der linken Eingaberelation.";
+      }
     };
 
     this.getColumns = function() {
@@ -39,33 +53,19 @@ function Division(input1, input2) {
     this.setColumns = null;
 
     this.getResult = function() {
-
         this.validate();
-
         var cols = this.getColumns();
-
-        console.log(cols);
-
         var pro = new Projection(cols.toString(), this.input1);
-
         var cp = new Crossproduct(pro, this.input2);
-
         var namingCommand = "";
-
         var cpColumns = cp.getColumns();
-
         for (var i=0;i<cpColumns.length;i++) {
           namingCommand += cpColumns[i].split(".")[1] + "<-" + cpColumns[i] + ",";
         }
-
         var newNames = new Rename(namingCommand,cp);
-
         var min = new Minus(newNames, this.input1);
-
         var proj = new Projection(cols.toString(), min);
-
         min = new Minus(pro, proj);
-
         return min.getResult();
     };
 

--- a/js/expression_intersection.js
+++ b/js/expression_intersection.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -29,14 +29,14 @@ function Intersection(input1, input2) {
         return new Intersection(this.input1.copy(), this.input2.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.input1.toHTML() + " " + latex("\\cap") + " " + this.input2.toHTML() + ")";
+        display += '(' + this.input1.toHTML(options) + " " + latex("\\cap") + " " + this.input2.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.input1.toLatex() + "\\cap " + this.input2.toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.input1.toLatex(options) + "\\cap " + this.input2.toLatex(options) + ")";
     }
 }
 Intersection.prototype = new Minus;

--- a/js/expression_join.js
+++ b/js/expression_join.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -128,7 +128,7 @@ function Join(input1, input2) {
                         } else {
 							// already added
 						}
-                    }	
+                    }
                     /*for (i = 0; i < col1.length - joincolumns.length; i++) {
                         newrow.unshift(null);
                     }*/
@@ -144,14 +144,14 @@ function Join(input1, input2) {
         return new Join(this.input1.copy(), this.input2.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.input1.toHTML() + " " + latex("\\bowtie") + " " + this.input2.toHTML() + ")";
+        display += '(' + this.input1.toHTML(options) + " " + latex("\\bowtie") + " " + this.input2.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.input1.toLatex() + "\\bowtie " + this.input2.toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.input1.toLatex(options) + "\\bowtie " + this.input2.toLatex(options) + ")";
     }
 }
 Join.prototype = new Relation();

--- a/js/expression_left_outer_join.js
+++ b/js/expression_left_outer_join.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -30,14 +30,14 @@ function LeftOuterJoin(input1, input2) {
         return new LeftOuterJoin(this.getInput1().copy(), this.getInput1().copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.getInput1().toHTML() + " " + latex(symbol) + " " + this.getInput2().toHTML() + ")";
+        display += '(' + this.getInput1().toHTML(options) + " " + latex(symbol) + " " + this.getInput2().toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.getInput1().toLatex() + symbol + this.getInput2().toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.getInput1().toLatex(options) + symbol + this.getInput2().toLatex(options) + ")";
     }
 }
 LeftOuterJoin.prototype = new Join;

--- a/js/expression_left_semi_join.js
+++ b/js/expression_left_semi_join.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -40,14 +40,14 @@ function LeftSemiJoin(input1, input2) {
         return new LeftSemiJoin(this.input1.copy(), this.input2.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.input1.toHTML() + " " + latex("\\ltimes") + " " + this.input2.toHTML() + ")";
+        display += '(' + this.input1.toHTML(options) + " " + latex("\\ltimes") + " " + this.input2.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.input1.toLatex() + "\\ltimes " + this.input2.toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.input1.toLatex(options) + "\\ltimes " + this.input2.toLatex(options) + ")";
     }
 }
 LeftSemiJoin.prototype = new Relation;

--- a/js/expression_minus.js
+++ b/js/expression_minus.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -85,14 +85,14 @@ function Minus(input1, input2) {
         return new Minus(this.input1.copy(), this.input2.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.input1.toHTML() + " " + latex("\\setminus") + " " + this.input2.toHTML() + ")";
+        display += '(' + this.input1.toHTML(options) + " " + latex("\\setminus") + " " + this.input2.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.input1.toLatex() + "\\setminus " + this.input2.toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.input1.toLatex(options) + "\\setminus " + this.input2.toLatex(options) + ")";
     }
 }
 Minus.prototype = new Relation();

--- a/js/expression_minus.js
+++ b/js/expression_minus.js
@@ -22,17 +22,18 @@ function Minus(input1, input2) {
     this.setChildren([this.input1, this.input2]);
 
     this.validate = function() {
-        if (this.input1.getColumns() == null || this.input2.getColumns() == null) {
+      var leftInputColumns = this.input1.getColumns();
+      var rightInputColumns = this.input2.getColumns();
+        if (leftInputColumns == null || rightInputColumns == null) {
             throw "Es fehlt mindestens eine Eingaberelation.";
         }
 
-        if (this.input1.getColumns().length != this.input2.getColumns().length) {
+        if (leftInputColumns.length != rightInputColumns.length) {
             throw "Die Spaltenzahl und Namen der zwei Eingaberelationen müssen für Minus gleich sein!";
         }
 
-        cols2 = this.input2.getColumns();
-        this.input1.getColumns().each(function(c, nr) {
-            if (c != cols2[nr]) {
+        leftInputColumns.each(function(c, nr) {
+            if (c != rightInputColumns[nr]) {
                 throw "Die Spaltenzahl und Namen der zwei Eingaberelationen müssen für Minus gleich sein!";
             }
         });

--- a/js/expression_outer_join.js
+++ b/js/expression_outer_join.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -29,14 +29,14 @@ function OuterJoin(input1, input2) {
         return new OuterJoin(this.input1.copy(), this.input2.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.getInput1().toHTML() + ") " + latex(symbol) + " (" + this.getInput2().toHTML() + ")";
+        display += '(' + this.getInput1().toHTML(options) + ") " + latex(symbol) + " (" + this.getInput2().toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.getInput1().toLatex() + symbol + this.getInput2().toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.getInput1().toLatex(options) + symbol + this.getInput2().toLatex(options) + ")";
     }
 }
 OuterJoin.prototype = new Join;

--- a/js/expression_projection.js
+++ b/js/expression_projection.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -79,15 +79,15 @@ function Projection(columns, input) {
         return new Projection(this.columns, this.input.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '(';
         display += latex("\\Pi");
-        display += '<span style=\'font-size:10pt; vertical-align: bottom\'>' + this.columns + "</span> " + this.input.toHTML() + ")";
+        display += '<span style=\'font-size:10pt; vertical-align: bottom\'>' + this.columns + "</span> " + this.input.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(\\Pi_{" + this.columns + "}" + this.input.toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(\\Pi_{" + this.columns + "}" + this.input.toLatex(options) + ")";
     }
 }
 Projection.prototype = new Relation;

--- a/js/expression_rename.js
+++ b/js/expression_rename.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -70,17 +70,17 @@ function Rename(renames, input) {
         return new Rename(renames, this.input.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '(';
         display += latex("\\rho");
-        display += '<span style=\'font-size:10pt; vertical-align: bottom\'>' + renames + "</span> " + this.input.toHTML() + ")";
+        display += '<span style=\'font-size:10pt; vertical-align: bottom\'>' + renames + "</span> " + this.input.toHTML(options) + ")";
         return display;
     }
 
 
-    this.toLatex = function() {
+    this.toLatex = function(options) {
         var lcol = renames.gsub("<-", '\\leftarrow ')
-        return "\\rho_{" + lcol + "}" + input.toLatex();
+        return "\\rho_{" + lcol + "}" + input.toLatex(options);
     }
 }
 Rename.prototype = new Relation();

--- a/js/expression_right_outer_join.js
+++ b/js/expression_right_outer_join.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -30,14 +30,14 @@ function RightOuterJoin(input1, input2) {
         return new RightOuterJoin(this.input1.copy(), this.input2.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.getInput1().toHTML() + " " + latex(symbol) + " " + this.getInput2().toHTML() + ")";
+        display += '(' + this.getInput1().toHTML(options) + " " + latex(symbol) + " " + this.getInput2().toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.getInput1().toLatex() + symbol + this.getInput2().toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.getInput1().toLatex(options) + symbol + this.getInput2().toLatex(options) + ")";
     }
 }
 RightOuterJoin.prototype = new Join;

--- a/js/expression_right_semi_join.js
+++ b/js/expression_right_semi_join.js
@@ -40,14 +40,14 @@ function RightSemiJoin(input1, input2) {
         return new RightSemiJoin(this.input1.copy(), this.input2.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.input1.toHTML() + " " + latex("\\rtimes") + " " + this.input2.toHTML() + ")";
+        display += '(' + this.input1.toHTML(options) + " " + latex("\\rtimes") + " " + this.input2.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.input1.toLatex() + "\\rtimes " + this.input2.toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.input1.toLatex(options) + "\\rtimes " + this.input2.toLatex(options) + ")";
     }
 }
 RightSemiJoin.prototype = new Relation;

--- a/js/expression_union.js
+++ b/js/expression_union.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -84,14 +84,14 @@ function Union(input1, input2) {
         return new Union(this.input1.copy(), this.input2.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '';
-        display += '(' + this.input1.toHTML() + " " + latex("\\cup") + " " + this.input2.toHTML() + ")";
+        display += '(' + this.input1.toHTML(options) + " " + latex("\\cup") + " " + this.input2.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "(" + this.input1.toLatex() + "\\cup " + this.input2.toLatex() + ")";
+    this.toLatex = function(options) {
+        return "(" + this.input1.toLatex(options) + "\\cup " + this.input2.toLatex(options) + ")";
     }
 }
 Union.prototype = new Relation();

--- a/js/relation.js
+++ b/js/relation.js
@@ -41,11 +41,11 @@ function Relation() {
         throw "Der Ausdruck ist nicht vollständig definiert, es fehlt eine Relation.";
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         return '<a id="block_' + this.blockId + '" class="block" href="javascript:;" onclick="editExpression(getBlock(' + this.blockId + '));">Ausdruck</a>';
     }
 
-    this.toLatex = function() {
+    this.toLatex = function(options) {
         return "\\emptyset";
     }
 }

--- a/js/selection.js
+++ b/js/selection.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -57,14 +57,14 @@ function Selection(condition, input) {
         return new Selection(this.condition.copy(), this.input.copy());
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '(' + latex("\\sigma");
-        display += '<span style=\'font-size:10pt; vertical-align: bottom\'>' + this.condition.toHTML() + "</span> " + this.input.toHTML() + ")";
+        display += '<span style=\'font-size:10pt; vertical-align: bottom\'>' + this.condition.toHTML(options) + "</span> " + this.input.toHTML(options) + ")";
         return display;
     }
 
-    this.toLatex = function() {
-        return "\\sigma_{" + this.condition.toLatex() + "}" + this.input.toLatex() + "";
+    this.toLatex = function(options) {
+        return "\\sigma_{" + this.condition.toLatex(options) + "}" + this.input.toLatex(options) + "";
     }
 }
 Selection.prototype = new Relation();

--- a/js/value.js
+++ b/js/value.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -27,13 +27,13 @@ function Value() {
         //throw "Der Ausdruck ist nicht vollständig definiert, es fehlt ein Wert.";
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         var display = '<a id="block_' + this.blockId + '" class="block" href="javascript:;" ' +
         'onclick="editExpression(getBlock(' + this.blockId + '));">Wert</a> ';
         return display;
     }
 
-    this.toLatex = function() {
+    this.toLatex = function(options) {
         return "?";
     }
 }

--- a/js/value_column.js
+++ b/js/value_column.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -28,11 +28,11 @@ function ValueColumn(col) {
         // currentRow needs to be filled before this is eval'd
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         return this.column;
     }
 
-    this.toLatex = function() {
+    this.toLatex = function(options) {
         return '\\textrm{' + this.column.gsub("_", "\\_") + '}';
     }
 }

--- a/js/value_literal.js
+++ b/js/value_literal.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -26,11 +26,11 @@ function ValueLiteral(lit) {
         return "\"" + this.literal + "\"";
     }
 
-    this.toHTML = function() {
+    this.toHTML = function(options) {
         return "'" + this.literal + "'";
     }
 
-    this.toLatex = function() {
+    this.toLatex = function(options) {
         return "'\\textrm{" + this.literal + "}'";
     }
 }

--- a/lib/prototype.js
+++ b/lib/prototype.js
@@ -50,7 +50,7 @@ var Prototype = {
   JSONFilter: /^\/\*-secure-([\s\S]*)\*\/\s*$/,
 
   emptyFunction: function() { },
-  K: function(x) { return x }
+  K: function(x) { return x; }
 };
 
 if (Prototype.Browser.MobileSafari)
@@ -79,7 +79,7 @@ var Try = {
 /* Based on Alex Arnell's inheritance implementation. */
 
 var Class = (function() {
-  function subclass() {};
+  function subclass() {}
   function create() {
     var parent = null, properties = $A(arguments);
     if (Object.isFunction(properties[0]))
@@ -95,7 +95,7 @@ var Class = (function() {
 
     if (parent) {
       subclass.prototype = parent.prototype;
-      klass.prototype = new subclass;
+      klass.prototype = new subclass();
       parent.subclasses.push(klass);
     }
 

--- a/schema.js
+++ b/schema.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -127,5 +127,20 @@ var zehnkampf = new DataRelation(
 ["Behrenbruch",8126],
 ["Hardee",8671],
 ["Sebrle",8869]
+]
+);
+
+var zehnkampfd = new DataRelation(
+"ZehnkampfD",
+["Name","Disziplin","Punkte"],
+[
+  ["Bolt","100m",50],
+  ["Bolt","Weitsprung",50],
+  ["Eaton","100m",40],
+  ["Eaton","Weitsprung",60],
+  ["Suarez","100m",60],
+  ["Suarez","Weitsprung",60],
+  ["Behrenbruch","100m",30],
+  ["Behrenbruch","Weitsprung",50]
 ]
 );

--- a/uicode.js
+++ b/uicode.js
@@ -344,8 +344,8 @@ function updateDisplay(reset) {
         var key = kvp.key;
         var a = document.createElement('li');
         list.appendChild(a);
-        a.innerHTML = '<a href="javascript:;" onclick="addDataRelation(saves.get(\'' + key + '\'))">' +
-        '<img border="0" src="http://www.mathtran.org/cgi-bin/toy/?tex=' + key + '" alt="' + key + '" /> Relation einsetzen  </a>';
+        a.innerHTML = '<a href="javascript:;" onclick="addDataRelation(saves.get(\'' + key + '\'))">'
+        + '$\\large{' + key + '}$ Relation einsetzen  </a>';
     });
 
     // update expression display

--- a/uicode.js
+++ b/uicode.js
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 debug = false;
 saves = new Hash();
 expressionHistory = new Array();
+showFull = false;
 
 function reset() {
     blockid = 0;
@@ -28,11 +29,12 @@ function reset() {
 
 function save(name) {
     saves.set(name,
-    new DataRelation(
-    name,
-    expression.getColumns(),
-    expression.getResult()
-    )
+		new DataRelation(
+			name,
+			expression.getColumns(),
+			expression.getResult(),
+			expression
+		)
     );
     reset();
 }
@@ -489,4 +491,9 @@ function latex(str) {
     //return ' <img border="0" src="http://www.mathtran.org/cgi-bin/toy/?tex='+str+'" alt="'+str+'"/> ';
     //return ' <img border="0" src="http://dbkemper4-vm10.informatik.tu-muenchen.de/~muehe/cgi-bin/mathtex.cgi?' + encodeURIComponent('\\gammacorrection{.9}\\png\\dpi{' + dpi + '}' + s) + '" alt="' + escape(s) + '"/> ';
 	return "<span>$" + str + "$</span>";
+}
+
+function toggleDisplayFull(){
+	showFull = !showFull;
+	updateDisplay(reset);
 }

--- a/uicode.js
+++ b/uicode.js
@@ -1,4 +1,4 @@
-/* 
+/*
 IRA - Interactive Relational Algebra Tool
 Copyright (C) 2010-2012 Henrik Mühe
 
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 debug = false;
 saves = new Hash();
 expressionHistory = new Array();
-showFull = false;
+inlineUserDefinedRelations = false;
 
 function reset() {
     blockid = 0;
@@ -353,7 +353,10 @@ function updateDisplay(reset) {
     display.innerHTML = "";
     var a = document.createElement('div');
     display.appendChild(a);
-    a.innerHTML = expression.toHTML();
+    var displayOptions = {
+      inline: inlineUserDefinedRelations
+    };
+    a.innerHTML = expression.toHTML(displayOptions);
 
     if (reset)
     resetCurrentBlock();
@@ -393,12 +396,12 @@ function updateDisplay(reset) {
     }
 
     // latex display
-    $("display_expression_latex").innerHTML = latex(expression.toLatex());
+    $("display_expression_latex").innerHTML = latex(expression.toLatex(displayOptions));
 
     highlightBlock(currentBlock);
 
     updateResult();
-	
+
 	MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
 }
 
@@ -498,7 +501,7 @@ function latex(str) {
 	return "<span>$" + str + "$</span>";
 }
 
-function toggleDisplayFull(){
-	showFull = !showFull;
+function toggleInlineUserDefinedRelations(){
+	inlineUserDefinedRelations = !inlineUserDefinedRelations;
 	updateDisplay(reset);
 }

--- a/uicode.js
+++ b/uicode.js
@@ -219,6 +219,18 @@ function addMinus() {
     updateDisplay(true);
 }
 
+function addDivision() {
+    saveHistory();
+    var rel = wrapAroundCheck();
+    if (rel === null) return;
+    // not a Relation if this happens
+    Object.extend(currentBlock,
+    addBlock(new Division(
+    leftSide() ? addBlock(rel, true) : addBlock(new Relation()),
+    leftSide() ? addBlock(new Relation()) : addBlock(rel, true))));
+    updateDisplay(true);
+}
+
 function addIntersection() {
     saveHistory();
     var rel = wrapAroundCheck();

--- a/uicode.js
+++ b/uicode.js
@@ -28,6 +28,11 @@ function reset() {
 }
 
 function save(name) {
+	if(name == null)
+		return;
+	name = name.trim();
+	if(name.length == 0)
+		return;
     saves.set(name,
 		new DataRelation(
 			name,


### PR DESCRIPTION
A user defined relation (UDR) only contains the materialized result but not the algebra expression itself. Thus, the original expression is no longer available and cannot be displayed in the browser when a UDR is used as part of another expression.

This patch (contributed by the student DerGenaue) adds an "inline" feature that allows the user to display the entire expression.
We use this feature in the lecture to "modularize" complex algebra expressions. 
